### PR TITLE
ci(workflows): pin GitHub Actions dependencies to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,16 +20,16 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
       with:
         distribution: 'temurin'
         java-version: '17'
 
     - name: Cache Gradle packages
-      uses: actions/cache@v3
+      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to their full commit SHA for supply-chain security.

## Changes

- Pin 5 action references across 2 workflow files to commit SHAs
- Version tags preserved in comments for readability

### Changed Files
- `.github/workflows/build.yml`
- `.github/workflows/release.yml`

## Testing

- Workflow syntax is unchanged; only the `@ref` portion of `uses:` directives is modified
- All pinned SHAs correspond to the exact same code as the original version tags

## Memory / Performance Impact

N/A - CI configuration only.

## Related Issues

Closes #4
